### PR TITLE
Update multiexp.rs

### DIFF
--- a/src/gpu/multiexp.rs
+++ b/src/gpu/multiexp.rs
@@ -320,9 +320,15 @@ where
                                 let mut acc = <G as CurveAffine>::Projective::zero();
                                 let mut jack_chunk = kern.n;
                                 let size_result = std::mem::size_of::<<G as CurveAffine>::Projective>();
+                                info!("GABEDEBUG: start size_result:{}, jack_chunk:{},", size_result,jack_chunk);
                                 if size_result > 144 {
-                                    jack_chunk = (jack_chunk as f64 / 10f64).ceil() as usize;
+                                    jack_chunk = (jack_chunk as f64 / 15f64).ceil() as usize;
+                                    info!("GABEDEBUG: >144 size_result:{}, jack_chunk:{},", size_result,jack_chunk);
+                                }else{
+                                    jack_chunk = (jack_chunk as f64 / 1.2f64).ceil() as usize;
+                                    info!("GABEDEBUG: <=144 size_result:{}, jack_chunk:{},", size_result,jack_chunk);
                                 }
+                                info!("GABEDEBUG: end size_result:{}, jack_chunk:{},", size_result,jack_chunk);
                                 for (bases, exps) in bases.chunks(jack_chunk).zip(exps.chunks(jack_chunk)) {
                                     let result = kern.multiexp(bases, exps, bases.len())?;
                                     acc.add_assign(&result);


### PR DESCRIPTION
Consider reducing jack_chunk for less than 144,Another way to solve the problem of insufficient video memory

2021-01-26T06:39:49.056 INFO bellperson::gpu::multiexp > GABEDEBUG: <G> size:104, <PrimeField> size:32, <Projective> size:144
2021-01-26T06:39:49.056 INFO bellperson::gpu::multiexp > GABEDEBUG: GPU mem need:11227211672byte, 10707Mbyte
2021-01-26T06:39:49.572 WARN bellperson::gpu::locks > GPU Multiexp failed! Falling back to CPU... Error: OpenCL Error: Ocl Error:

################################ OPENCL ERROR ###############################

Error executing function: clEnqueueWriteBuffer

Status error code: CL_MEM_OBJECT_ALLOCATION_FAILURE (-4)

Please visit the following url for more information:

https://www.khronos.org/registry/cl/sdk/1.2/docs/man/xhtml/clEnqueueWriteBuffer.html#errors

#############################################################################